### PR TITLE
Unknown function errors

### DIFF
--- a/lib/ftp/bifrost.ex
+++ b/lib/ftp/bifrost.ex
@@ -357,7 +357,7 @@ defmodule Ftp.Bifrost do
       ) do
     working_path = determine_path(root_dir, current_directory, filename)
 
-    if allowed_to_store?(permissions, working_path, state) do
+    if allowed_to_write?(permissions, working_path, state) do
       Logger.debug("working_dir: #{working_path}")
 
       case File.exists?(working_path) do
@@ -639,10 +639,6 @@ defmodule Ftp.Bifrost do
     else
       file_handler.allowed_to_write?(working_path, name)
     end
-  end
-
-  defp allowed_to_store?(permissions, working_path, state) do
-    allowed_to_write?(permissions, working_path, state)
   end
 
   @doc """

--- a/lib/ftp/bifrost.ex
+++ b/lib/ftp/bifrost.ex
@@ -357,7 +357,7 @@ defmodule Ftp.Bifrost do
       ) do
     working_path = determine_path(root_dir, current_directory, filename)
 
-    if allowed_to_stor?(permissions, working_path, state) do
+    if allowed_to_store?(permissions, working_path, state) do
       Logger.debug("working_dir: #{working_path}")
 
       case File.exists?(working_path) do
@@ -641,7 +641,7 @@ defmodule Ftp.Bifrost do
     end
   end
 
-  defp allowed_to_stor?(permissions, working_path, state) do
+  defp allowed_to_store?(permissions, working_path, state) do
     allowed_to_write?(permissions, working_path, state)
   end
 
@@ -650,7 +650,7 @@ defmodule Ftp.Bifrost do
   and only show the files specified in the `limit_viewable_dirs` struct.
   """
   def remove_hidden_folders(
-        %{root_dir: root_dir, viewable_dirs: viewable_dirs} = permissions,
+        %{root_dir: root_dir, viewable_dirs: viewable_dirs},
         path,
         files
       ) do

--- a/lib/ftp/permissions.ex
+++ b/lib/ftp/permissions.ex
@@ -1,5 +1,4 @@
 defmodule Ftp.Permissions do
-  import Ftp.Path
   require Logger
 
   defstruct root_dir: "",
@@ -14,7 +13,7 @@ defmodule Ftp.Permissions do
   the original `current_path`
   """
   def allowed_to_read?(
-        %__MODULE__{root_dir: root_dir, viewable_dirs: viewable_dirs, enabled: enabled} =
+        %__MODULE__{root_dir: root_dir, viewable_dirs: _, enabled: enabled} =
           permissions,
         current_path
       ) do
@@ -108,7 +107,7 @@ defmodule Ftp.Permissions do
   Function used to determine if a user is allowed to write to the `current_path`
   """
   def allowed_to_write?(
-        %__MODULE__{root_dir: root_dir, viewable_dirs: viewable_dirs, enabled: enabled} =
+        %__MODULE__{root_dir: root_dir, viewable_dirs: _, enabled: enabled} =
           permissions,
         current_path
       ) do
@@ -155,7 +154,7 @@ defmodule Ftp.Permissions do
   and only show the files specified in the `limit_viewable_dirs` struct.
   """
   def remove_hidden_folders(
-        %__MODULE__{root_dir: root_dir, viewable_dirs: viewable_dirs} = permissions,
+        %__MODULE__{root_dir: root_dir, viewable_dirs: viewable_dirs},
         path,
         files
       ) do

--- a/lib/ftp/permissions.ex
+++ b/lib/ftp/permissions.ex
@@ -13,7 +13,7 @@ defmodule Ftp.Permissions do
   `root_path` string from the `current_path` string. If not, it will simply return
   the original `current_path`
   """
-  def allowed_to_read(
+  def allowed_to_read?(
         %__MODULE__{root_dir: root_dir, viewable_dirs: viewable_dirs, enabled: enabled} =
           permissions,
         current_path
@@ -107,7 +107,7 @@ defmodule Ftp.Permissions do
   @doc """
   Function used to determine if a user is allowed to write to the `current_path`
   """
-  def allowed_to_write(
+  def allowed_to_write?(
         %__MODULE__{root_dir: root_dir, viewable_dirs: viewable_dirs, enabled: enabled} =
           permissions,
         current_path
@@ -126,7 +126,7 @@ defmodule Ftp.Permissions do
   Function used to determine if a user is allowed to write a file in the the `file_path`
   """
   def allowed_to_stor(%__MODULE__{} = permissions, file_path) do
-    allowed_to_write(permissions, Path.dirname(file_path))
+    allowed_to_write?(permissions, Path.dirname(file_path))
   end
 
   @doc """


### PR DESCRIPTION
There were functions being called with `?` at the call site, but not at
the function implementation. This caused a warning at compile time and
a bug at runtime that was crashing the entire FTP server. The tests were
also failing