### PR TITLE
Return atom instead of state in error for stor

### DIFF
--- a/lib/ftp/bifrost.ex
+++ b/lib/ftp/bifrost.ex
@@ -359,7 +359,7 @@ defmodule Ftp.Bifrost do
 
     if allowed_to_write?(permissions, working_path, state) do
       Logger.debug("working_dir: #{working_path}")
-
+      
       case File.exists?(working_path) do
         true -> File.rm(working_path)
         false -> :ok
@@ -375,10 +375,10 @@ defmodule Ftp.Bifrost do
         :error ->
           ## TODO cannot seem to produce this event ##
           Ftp.EventDispatcher.dispatch(:e_transfer_failed)
-          {:error, state}
+          {:error, :e_transfer_failed }
       end
     else
-      {:error, state}
+      {:error, :eacces}
     end
   end
 


### PR DESCRIPTION
STOR command was returning the state in the tuple which was then
being seen by the user. If you look in the bifrost.erl file, we
can see that upon error for the put_file function, we should be
return 'Info', not 'State'.