### PR TITLE
Change ets lookup to case statement.

### DIFF
--- a/lib/ftp/bifrost.ex
+++ b/lib/ftp/bifrost.ex
@@ -82,11 +82,12 @@ defmodule Ftp.Bifrost do
 
     state = struct(State, options)
 
-    if ets_table_exists?(state.server_name) do
-      :ets.insert(state.server_name, {:max_sessions, state.max_sessions})
-      :ets.insert(state.server_name, {:current_sessions, state.current_sessions})
-    else
-      Logger.warn("No ets table of name #{inspect state.server_name}. Limited connections for this FTP server (#{inspect state.server_name}) may not work correctly")
+    case ets_table_exists(state.server_name) do
+      :ok ->
+        :ets.insert(state.server_name, {:max_sessions, state.max_sessions})
+        :ets.insert(state.server_name, {:current_sessions, state.current_sessions})
+      _ ->
+        Logger.warn("No ets table of name #{inspect state.server_name}. Limited connections for this FTP server (#{inspect state.server_name}) may not work correctly")
     end
     state
   end

--- a/lib/ftp/supervisor.ex
+++ b/lib/ftp/supervisor.ex
@@ -20,7 +20,10 @@ defmodule Ftp.Supervisor do
   end
 
   def start_server(name, options) do
-    unless ets_table_exists?(name), do: :ets.new(name, [:public, :named_table])
+    case ets_table_exists(name) do 
+      {:error, :eexist} -> :ets.new(name, [:public, :named_table])
+      _ -> :ok
+    end
     Supervisor.start_child(@server_name, %{
       id: name,
       start: {:bifrost, :start_link, [Ftp.Bifrost, options]}
@@ -36,7 +39,10 @@ defmodule Ftp.Supervisor do
   def stop_server(name) do
     Supervisor.terminate_child(@server_name, name)
     Supervisor.delete_child(@server_name, name)
-    if ets_table_exists?(name), do: :ets.delete(name)
+    case ets_table_exists(name) do
+      :ok -> :ets.delete(name)
+      _ -> :ok
+    end
     :ok
   end
 end

--- a/lib/ftp/utils.ex
+++ b/lib/ftp/utils.ex
@@ -4,18 +4,20 @@ defmodule Ftp.Utils do
     """
 
     @doc """
-    Fuction to return `true` or `false` when a table with name `name` of type `Atom`
-    exists or not.
+    Fuction to return:
+      `:ok` when a table with name `name` of type `Atom` exists
+      `{:error, :eexist}` when a table with name `name` of type `Atom` does not exist
+      `{:error, :undef}` If an UndefinedFunctionError is returned, which can happen if the user is using OTP < 21
     """
-    def ets_table_exists?(name) when is_atom(name) do
+    def ets_table_exists(name) when is_atom(name) do
         try do
           case :ets.whereis(name) do
-          :undefined -> false
-          _tid -> true
+            :undefined -> {:error, :eexist}
+            _tid -> :ok
           end
         rescue
           ## ets.whereis was only added in OTP 21, so user will get this error if they try to use an older version
-          UndefinedFunctionError -> false
+          UndefinedFunctionError -> {:error, :undef}
         end
     end
 end


### PR DESCRIPTION
This is because there is a case where a table can be created, but the lookup would still have returned "false" if the user was using OTP < 20. This can lead to a crash because if the user tries to create the table again (because they were told it did not exist), they will get an ArgumentError, which will then cause a crash.