### PR TITLE
Session management

### DIFF
--- a/lib/ftp/bifrost.ex
+++ b/lib/ftp/bifrost.ex
@@ -13,13 +13,11 @@ defmodule Ftp.Bifrost do
   Record.defrecord(
     :file_info,
     Record.extract(:file_info, from: "#{__DIR__}/../../include/bifrost.hrl")
-    # Record.extract(:file_info, from: "/srv/erlang/lib/se_ftp-0.1.0/include/bifrost.hrl")
   )
 
   Record.defrecord(
     :connection_state,
     Record.extract(:connection_state, from: "#{__DIR__}/../../include/bifrost.hrl")
-    # Record.extract(:connection_state, from: "/srv/erlang/lib/se_ftp-0.1.0/include/bifrost.hrl")
   )
 
   defmodule State do
@@ -95,8 +93,12 @@ defmodule Ftp.Bifrost do
     state
   end
 
+  @doc """
+  This function is used add the session information (in this case, `conn_state`) of a given session for a server to the table.
+  """
   def update_session_table({res, conn_state}) do
     state = unpack_state(conn_state)
+    ## only store if there is a valid session_id and user
     if Map.get(state, :session) != nil and Map.get(state, :user) != nil do
       server_name = Map.get(state, :server_name)
       [{:active_sessions, current_active_sessions}] = :ets.lookup(server_name, :active_sessions)

--- a/lib/ftp/bifrost.ex
+++ b/lib/ftp/bifrost.ex
@@ -81,14 +81,15 @@ defmodule Ftp.Bifrost do
       |> Keyword.put(:expected_password, options[:password])
 
     state = struct(State, options)
+    server_name = Map.get(state, :server_name)
 
-    case ets_table_exists(state.server_name) do
+    case ets_table_exists(server_name) do
       :ok ->
-        :ets.insert(state.server_name, {:max_sessions, state.max_sessions})
-        :ets.insert(state.server_name, {:current_sessions, state.current_sessions})
-        :ets.insert(state.server_name, {:active_sessions, []})
+        :ets.insert(server_name, {:max_sessions, state.max_sessions})
+        :ets.insert(server_name, {:current_sessions, state.current_sessions})
+        :ets.insert(server_name, {:active_sessions, []})
       _ ->
-        Logger.warn("No ets table of name #{inspect state.server_name}. Limited connections for this FTP server (#{inspect state.server_name}) may not work correctly")
+        Logger.warn("No ets table of name #{inspect server_name}. Limited connections for this FTP server (#{inspect server_name}) may not work correctly")
     end
     state
   end

--- a/lib/ftp/utils.ex
+++ b/lib/ftp/utils.ex
@@ -2,6 +2,7 @@ defmodule Ftp.Utils do
     @moduledoc """
     Module for various utility functions
     """
+    require Logger
 
     @doc """
     Fuction to return:
@@ -19,5 +20,71 @@ defmodule Ftp.Utils do
           ## ets.whereis was only added in OTP 21, so user will get this error if they try to use an older version
           UndefinedFunctionError -> {:error, :undef}
         end
+    end
+
+    def ets_lookup(name, item) do
+      case ets_table_exists(name) do
+        :ok -> :ets.lookup(name, item)
+        error -> error
+      end
+    end
+
+    def get_active_sessions(server_name) when is_atom(server_name) do
+      case ets_lookup(server_name, :active_sessions) do
+        [{:active_sessions, active_sessions}] -> active_sessions
+        _ -> nil
+      end
+    end
+  
+    def close_session(server_name, session_to_delete) when is_atom(server_name) and is_binary(session_to_delete) do
+      case ets_lookup(server_name, :active_sessions) do
+        [{:active_sessions, active_sessions}] -> 
+          new_active_sessions = 
+          Enum.filter(active_sessions, fn conn_state ->
+            session_id = get_session_id(conn_state)
+            port = get_port(conn_state)
+            if session_id == session_to_delete do
+              close_port(port, session_id)
+              false
+            else
+              true
+            end
+          end)
+          if new_active_sessions == active_sessions do
+            Logger.info("Could not close session #{inspect session_to_delete} as it does not exist.")
+          end          
+          :ets.insert(server_name, {:active_sessions, new_active_sessions})
+        _ -> :ok
+      end
+    end
+
+    def close_port(port, session_id) when is_port(port) and is_binary(session_id) do
+      Logger.info("Closing port #{inspect port} for session #{inspect session_id}")
+      Port.close(port)
+    end
+  
+    def close_port(_port, _session_id) do
+      :ok
+    end
+  
+    @doc """
+    Function to return the `Port` if present in `conn_state`
+    """
+    def get_port(conn_state) when is_tuple(conn_state) do
+      port_index = 15 ## port location in conn_state
+      conn_state
+      |> Tuple.to_list()
+      |> Enum.at(port_index)
+    end
+  
+    @doc """
+    Function to return the session from `conn_state`
+    """
+    def get_session_id(conn_state) when is_tuple(conn_state) do
+      session_index = 8 ## %Ftp.Bifrost{} struct location in conn_state
+      conn_state
+      |> Tuple.to_list()
+      |> Enum.at(session_index)
+      |> Map.get(:session)
     end
 end

--- a/src/bifrost.erl
+++ b/src/bifrost.erl
@@ -222,7 +222,10 @@ control_loop(HookPid, {SocketMod, RawSocket} = Socket, State) ->
             end;
         {error, _Reason} ->
             ModuleState = State#connection_state.module_state,
+            Name = maps:get(server_name, ModuleState),
+            SessionId = maps:get(session, ModuleState),
             'Elixir.Ftp.EventDispatcher':dispatch(e_logout_successful, ModuleState),
+            'Elixir.Ftp.Utils':close_session(Name, SessionId),
             error_logger:warning_report({bifrost, connection_terminated})
     end.
 


### PR DESCRIPTION
Need to be able to keep track of more information regarding the active sessions, such as session_ids and erlang ports. This is so that we can close sessions based on their session_ids, if needs be.