### PR TITLE
Performance enhancements

### DIFF
--- a/lib/ftp/supervisor.ex
+++ b/lib/ftp/supervisor.ex
@@ -26,7 +26,7 @@ defmodule Ftp.Supervisor do
     end
     Supervisor.start_child(@server_name, %{
       id: name,
-      start: {:bifrost, :start_link, [Ftp.Bifrost, options]}
+      start: {:bifrost, :start_link, [Ftp.Bifrost, options, name]}
     })
   end
 

--- a/src/bifrost.erl
+++ b/src/bifrost.erl
@@ -10,7 +10,7 @@
 -include("bifrost.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
--export([start_link/2, establish_control_connection/2, await_connections/2, supervise_connections/1]).
+-export([start_link/2, establish_control_connection/2, await_connections/2]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2, code_change/3]).

--- a/src/connection_monitor.erl
+++ b/src/connection_monitor.erl
@@ -1,0 +1,37 @@
+-module(connection_monitor).
+
+-behaviour(gen_server).
+
+-export([start_link/1, monitor/2]).
+
+%% gen_server callbacks
+-export([init/1, handle_info/2, handle_call/3, handle_cast/2, terminate/2]).
+
+monitor(Name, Pid) ->
+    gen_server:cast(Name, {monitor, Pid}).
+
+start_link(Name) ->
+    gen_server:start_link({local, Name}, ?MODULE, [], []).
+
+init(_) ->
+    {ok, []}.  
+
+handle_call(_Request, _From, State) ->
+    {reply, ok, State}.
+
+handle_cast({monitor, Pid}, State) ->
+    erlang:monitor(process, Pid),
+    {noreply, State}.
+
+handle_info({'DOWN', _Ref, process, _Pid, normal}, State) ->
+    {noreply, State};
+
+handle_info({'DOWN', _Ref, process, _Pid, shutdown}, State) ->
+    {noreply, State};
+
+handle_info({'DOWN', _Ref, process, Pid, Info}, State) ->
+    error_logger:error_msg("Control connection ~p crashed: ~p~n", [Pid, Info]),
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.

--- a/src/connection_supervisor.erl
+++ b/src/connection_supervisor.erl
@@ -14,8 +14,7 @@ init(InitialState) ->
     {ok, InitialState}.  
 
 handle_call(_Request, _From, State) ->
-    Reply = ok,
-    {reply, Reply, State}.
+    {reply, ok, State}.
 
 handle_cast(_Msg, State) ->
     {noreply, State}.
@@ -26,14 +25,14 @@ handle_info({new_connection, Acceptor, Socket}, InitialState) ->
     {noreply, InitialState};
 
 handle_info({'EXIT', _Pid, normal}, State) ->
-    {stop, normal, State};
+    {noreply, normal, State};
 
 handle_info({'EXIT', _Pid, shutdown}, State) ->
-    {stop, shutdown, State};
+    {noreply, shutdown, State};
 
 handle_info({'EXIT', Pid, Info}, State) ->
     error_logger:error_msg("Control connection ~p crashed: ~p~n", [Pid, Info]),
-    {stop, bad_exit, State};
+    {noreply, bad_exit, State};
 
 handle_info(_, State) ->
     {noreply, State}.

--- a/src/connection_supervisor.erl
+++ b/src/connection_supervisor.erl
@@ -25,14 +25,14 @@ handle_info({new_connection, Acceptor, Socket}, InitialState) ->
     {noreply, InitialState};
 
 handle_info({'EXIT', _Pid, normal}, State) ->
-    {noreply, normal, State};
+    {noreply, State};
 
 handle_info({'EXIT', _Pid, shutdown}, State) ->
-    {noreply, shutdown, State};
+    {noreply, State};
 
 handle_info({'EXIT', Pid, Info}, State) ->
     error_logger:error_msg("Control connection ~p crashed: ~p~n", [Pid, Info]),
-    {noreply, bad_exit, State};
+    {noreply, State};
 
 handle_info(_, State) ->
     {noreply, State}.

--- a/src/connection_supervisor.erl
+++ b/src/connection_supervisor.erl
@@ -11,7 +11,6 @@ start_link([Args]) ->
     gen_server:start_link(?MODULE, Args, []).
 
 init(InitialState) ->
-    erlang:monitor(process, self()),
     {ok, InitialState}.  
 
 handle_call(_Request, _From, State) ->
@@ -23,21 +22,7 @@ handle_cast(_Msg, State) ->
 handle_info({new_connection, Acceptor, Socket}, InitialState) ->
     Worker = proc_lib:spawn_link(bifrost, establish_control_connection, [Socket, InitialState]),
             Acceptor ! {ack, Worker},
-    {noreply, InitialState};
+    {noreply, InitialState}.
 
-handle_info({'DOWN', _Ref, process, _Pid, normal}, State) ->
-    {noreply, State};
-
-handle_info({'DOWN', _Ref, process, _Pid, shutdown}, State) ->
-    {noreply, State};
-
-handle_info({'DOWN', _Ref, process, Pid, Info}, State) ->
-    error_logger:error_msg("Control connection ~p crashed: ~p~n", [Pid, Info]),
-    {noreply, State};
-
-handle_info(_, State) ->
-    {noreply, State}.
-
-terminate(Reason, _State) ->
-    error_logger:error_msg("GenServer terminating:  ~p", [Reason]),
+terminate(_Reason, _State) ->
     ok.

--- a/src/connection_supervisor.erl
+++ b/src/connection_supervisor.erl
@@ -11,7 +11,7 @@ start_link([Args]) ->
     gen_server:start_link(?MODULE, Args, []).
 
 init(InitialState) ->
-    process_flag(trap_exit, true),
+    erlang:monitor(process, self()),
     {ok, InitialState}.  
 
 handle_call(_Request, _From, State) ->
@@ -25,13 +25,13 @@ handle_info({new_connection, Acceptor, Socket}, InitialState) ->
             Acceptor ! {ack, Worker},
     {noreply, InitialState};
 
-handle_info({'EXIT', _Pid, normal}, State) ->
+handle_info({'DOWN', _Ref, process, _Pid, normal}, State) ->
     {noreply, State};
 
-handle_info({'EXIT', _Pid, shutdown}, State) ->
+handle_info({'DOWN', _Ref, process, _Pid, shutdown}, State) ->
     {noreply, State};
 
-handle_info({'EXIT', Pid, Info}, State) ->
+handle_info({'DOWN', _Ref, process, Pid, Info}, State) ->
     error_logger:error_msg("Control connection ~p crashed: ~p~n", [Pid, Info]),
     {noreply, State};
 

--- a/src/connection_supervisor.erl
+++ b/src/connection_supervisor.erl
@@ -11,6 +11,7 @@ start_link([Args]) ->
     gen_server:start_link(?MODULE, Args, []).
 
 init(InitialState) ->
+    process_flag(trap_exit, true),
     {ok, InitialState}.  
 
 handle_call(_Request, _From, State) ->

--- a/src/connection_supervisor.erl
+++ b/src/connection_supervisor.erl
@@ -1,0 +1,43 @@
+-module(connection_supervisor).
+
+-behaviour(gen_server).
+
+-export([start_link/1]).
+
+%% gen_server callbacks
+-export([init/1, handle_info/2, handle_call/3, handle_cast/2, terminate/2]).
+
+start_link([Args]) ->
+    gen_server:start_link(?MODULE, Args, []).
+
+init(InitialState) ->
+    {ok, InitialState}.  
+
+handle_call(_Request, _From, State) ->
+    Reply = ok,
+    {reply, Reply, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info({new_connection, Acceptor, Socket}, InitialState) ->
+    Worker = proc_lib:spawn_link(bifrost, establish_control_connection, [Socket, InitialState]),
+            Acceptor ! {ack, Worker},
+    {noreply, InitialState};
+
+handle_info({'EXIT', _Pid, normal}, State) ->
+    {stop, normal, State};
+
+handle_info({'EXIT', _Pid, shutdown}, State) ->
+    {stop, shutdown, State};
+
+handle_info({'EXIT', Pid, Info}, State) ->
+    error_logger:error_msg("Control connection ~p crashed: ~p~n", [Pid, Info]),
+    {stop, bad_exit, State};
+
+handle_info(_, State) ->
+    {noreply, State}.
+
+terminate(Reason, _State) ->
+    error_logger:error_msg("GenServer terminating:  ~p", [Reason]),
+    ok.


### PR DESCRIPTION
This PR is for a performance enhancement with regards to FTP. From my tests, I saw a 3-4% increase in CPU availability. It is worth noting that the FTP server was idling at this time with no clients connecting, and the NMC used was a chassis.

**The Fprof Profiling Test:**
1. Set a timer for exactly 5 mins as soon as the NMC reboots. Do not touch the NMC or log into it for 5 mins.
2. After 5 mins, start the profiling for exactly 20 seconds.

**The Performance Test:**
1. Set a timer for exactly 10 mins as soon as the NMC reboots. Do not touch the NMC or log into it for 10 mins.
2. After 10 mins, extract the performance_info.csv file.

I ran the Performance Test twice, (twice with this fix and twice without), and ran the Fprof Profiling Test once (once with this fix and once without). 

I have attached the results for anyone who wants to see.
[ftp_performance_testing.zip](https://github.com/se-apc/ftp/files/4421914/ftp_performance_testing.zip)
