### PR TITLE
Debug info

### DIFF
--- a/lib/ftp/bifrost.ex
+++ b/lib/ftp/bifrost.ex
@@ -27,6 +27,7 @@ defmodule Ftp.Bifrost do
               expected_username: nil,
               expected_password: nil,
               session: nil,
+              session_pid: nil,
               user: nil,
               permissions: nil,
               abort_agent: nil,
@@ -134,9 +135,10 @@ defmodule Ftp.Bifrost do
       when is_function(authentication_function, 3) do
     case authentication_function.(username, password, ip_address) do
       {:ok, session, user} ->
-        Logger.info("#{inspect(username)} successfully logged in.")
+        session_pid = self()
+        Logger.info("#{inspect(username)} successfully logged in. session_pid: #{inspect(session_pid)}.")
         Ftp.EventDispatcher.dispatch(:e_login_successful, state)
-        {true, %{state | session: session, user: user}}
+        {true, %{state | session: session, user: user, session_pid: session_pid}}
 
       {:error, error} ->
         Logger.error("#{inspect(username)} failed to logged in. Reason: #{inspect error}")
@@ -154,9 +156,10 @@ defmodule Ftp.Bifrost do
       ) do
     case {username, password} do
       {^expected_username, ^expected_password} ->
-        Logger.info("#{inspect(username)} successfully logged in.")
+        session_pid = self()
+        Logger.info("#{inspect(username)} successfully logged in. session_pid: #{inspect(session_pid)}.")
         Ftp.EventDispatcher.dispatch(:e_login_successful, state)
-        {true, %{state | user: expected_username}}
+        {true, %{state | user: expected_username,  session_pid: session_pid}}
 
       _ ->
         Logger.error("#{inspect(username)} failed to logged in.")
@@ -396,7 +399,9 @@ defmodule Ftp.Bifrost do
         %State{
           permissions: permissions,
           root_dir: root_dir,
-          current_directory: current_directory
+          current_directory: current_directory,
+          user: user,
+          session_pid: session_pid
         } = state,
         filename,
         mode,
@@ -416,6 +421,8 @@ defmodule Ftp.Bifrost do
 
       case receive_file(working_path, mode, recv_data) do
         :ok ->
+          file_size = File.lstat!(working_path).size
+          Logger.info("Received #{inspect(file_size)} bytes from #{inspect(user)} (session_pid: #{inspect(session_pid)}) ::: #{inspect self()}.")
           Ftp.EventDispatcher.dispatch(:e_transfer_successful, state)
           {:ok, state}
 
@@ -498,11 +505,12 @@ defmodule Ftp.Bifrost do
         {:error, :eperm}
 
       true ->
+        file_size = File.lstat!(working_path).size
         {:ok, file} = :file.open(working_path, [:read, :binary])
         :file.position(file, state.offset)
         state = set_abort(%{state | offset: 0}, false)
         Ftp.EventDispatcher.dispatch(:e_transfer_started, state)
-        {:ok, &send_file(state, file, &1), state}
+        {:ok, &send_file(state, file, file_size, &1), state}
     end
   end
 
@@ -639,15 +647,16 @@ defmodule Ftp.Bifrost do
     end
   end
 
-  def send_file(state, file, size) do
+  def send_file(state = %State{user: user, session_pid: session_pid}, file, file_size, size) do
     unless aborted?(state) do
       case :file.read(file, size) do
         :eof ->
+          Logger.info("Sent #{inspect(file_size)} bytes to #{inspect(user)} (session_pid: #{inspect(session_pid)}).")
           Ftp.EventDispatcher.dispatch(:e_transfer_successful, state)
           {:done, state}
 
         {:ok, bytes} ->
-          {:ok, bytes, &send_file(state, file, &1)}
+          {:ok, bytes, &send_file(state, file, file_size, &1)}
 
         {:error, _} ->
           Ftp.EventDispatcher.dispatch(:e_transfer_failed, state)

--- a/src/bifrost.erl
+++ b/src/bifrost.erl
@@ -255,13 +255,13 @@ respond_raw({SocketMod, Socket}, Line) ->
 log_client_request(Request, State) ->
     ModuleState = State#connection_state.module_state,
     UserMap = maps:get(user, ModuleState),
-    SessionInfo = {erlang:self(), UserMap}
+    SessionInfo = {erlang:self(), UserMap},
     error_logger:info_report({bifrost, client_request, Request, SessionInfo}).
 
 log_server_response(Response, State) ->
     ModuleState = State#connection_state.module_state,
     UserMap = maps:get(user, ModuleState),
-    SessionInfo = {erlang:self(), UserMap}
+    SessionInfo = {erlang:self(), UserMap},
     error_logger:info_report({bifrost, server_response, Response, SessionInfo}).
 
 ssl_options(State) ->


### PR DESCRIPTION
- Add session_pid. This is the PID of the session. It provides a conscise way of tracking a session
- Print size file upon a successful upload or download.
- Print more info about the session as it starts and finishes
- Print out client requests
- Print out server responses